### PR TITLE
Handle calculator's error and prevent using eval()

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -99,8 +99,15 @@ const Button = ({ text, setDisplay, display, equation, setEquation }) => {
       calculateTrigonometric("arctan");
     }
     else if (text === "=") {
-      setDisplay(eval(equation));
-      setEquation(eval(equation));
+      try {
+        const result = Function(`'use strict'; return (${equation})`)();
+        setDisplay(result);
+        setEquation(result);
+      } catch (error) {
+        console.error(error);
+        setDisplay("Error");
+        setEquation("");
+      }
     } else {
       setDisplay(display === "0" ? text : display + text);
       setEquation(equation + text);


### PR DESCRIPTION
While we press the trigonometric function before any numbers, then followed with a number and equal sign will output an error. Instead of throwing the error screen, I added a try-catch block to display the "Error" on the calculator and also remove the use of eval() function as it is not a recommended way to do https://www.digitalocean.com/community/tutorials/js-eval#.